### PR TITLE
build: Setup publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
       - name: Build with Gradle Wrapper
-        run: ./gradlew build koverXmlReport
+        run: ./gradlew build koverXmlReport publishToMavenLocal
       - name: Upload coverage report
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         if: ${{ hashFiles('build/reports/kover/report.xml') != '' }}

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = 'tech.apter.junit5.jupiter'
-    version = '1.0-SNAPSHOT'
+    version = property('apter.junit5.robolectric.extension.version')
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 kotlin.code.style=official
+apter.junit5.robolectric.extension.version=0.1.0-SNAPSHOT

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,64 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifact(kotlinSourcesJar)
+            artifact(dokkaJavadocJar)
+
+            pom {
+                name = 'JUnit5 Robolectric Extension'
+                description = """This repository aims to bridge the gap between JUnit 5 and Robolectric, 
+                    |enabling developers to leverage the benefits of both frameworks 
+                    |for unit testing Android applications. While Robolectric currently lacks 
+                    |a dedicated JUnit 5 extension, this project proposes a community-driven solution to 
+                    |achieve seamless integration.""".stripMargin()
+                url = 'https://github.com/apter-tech/junit5-robolectric-extension'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                organization {
+                    name = 'Apter Technologies Ltd.'
+                    url = 'https://apter.tech'
+                }
+                developers {
+                    developer {
+                        id = 'warnyul'
+                        name = 'Balázs Varga'
+                        email = 'balazs.varga@apter.tech'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com:apter-tech/junit5-robolectric-extension.git'
+                    developerConnection = 'scm:git:ssh://github.com:apter-tech/junit5-robolectric-extension.git'
+                    url = 'https://github.com/apter-tech/junit5-robolectric-extension'
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = 'MavenCentral'
+            final releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+            final snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
+            url = version.toString().endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username = System.getenv('JUNIT5_ROBOLECTRIC_EXTENSION_MAVEN_USERNAME')
+                password = System.getenv('JUNIT5_ROBOLECTRIC_EXTENSION_MAVEN_PASSWORD')
+            }
+        }
+    }
+}
+
+//signing {
+//    useInMemoryPgpKeys(
+//        System.getenv('JUNIT5_ROBOLECTRIC_EXTENSION_PGP_SIGNING_KEY'),
+//        System.getenv('JUNIT5_ROBOLECTRIC_EXTENSION_PGP_SIGNING_PASSWORD'),
+//    )
+//    sign(publishing.publications["mavenJava"])
+//}

--- a/integration-tests/agp-groovy-dsl/build.gradle
+++ b/integration-tests/agp-groovy-dsl/build.gradle
@@ -26,9 +26,8 @@ android {
 }
 
 detekt {
-    version = libs.versions.detekt.get()
+    toolVersion = libs.versions.detekt.get()
     autoCorrect = true
-    config.setFrom(rootProject.layout.projectDirectory.file('config/detekt/detekt.yml').asFile)
 }
 
 kotlin {

--- a/integration-tests/agp-kotlin-dsl/build.gradle.kts
+++ b/integration-tests/agp-kotlin-dsl/build.gradle.kts
@@ -27,9 +27,8 @@ android {
 }
 
 detekt {
-    version = libs.versions.detekt.get()
+    toolVersion = libs.versions.detekt.get()
     autoCorrect = true
-    config.setFrom(rootProject.layout.projectDirectory.file("config/detekt/detekt.yml").asFile)
 }
 
 kotlin {

--- a/robolectric-extension/build.gradle
+++ b/robolectric-extension/build.gradle
@@ -24,7 +24,7 @@ test {
 }
 
 detekt {
-    version libs.versions.detekt.get()
+    toolVersion = libs.versions.detekt.get()
     autoCorrect true
 }
 
@@ -46,6 +46,12 @@ dependencies {
     testImplementation(libs.kotlinTestJUnit5)
     testImplementation(libs.junit5JupiterParams)
     testRuntimeOnly(libs.junit5JupiterEngine)
+}
+
+tasks.register('dokkaJavadocJar', Jar) {
+    dependsOn dokkaJavadoc
+    archiveClassifier.set 'javadoc'
+    from javadoc.destinationDir
 }
 
 private void bashExecute(String command) {
@@ -85,3 +91,5 @@ tasks.register('generateAndroidR') {
         bashExecute(aaptCommand)
     }
 }
+
+apply from: "${rootProject.layout.projectDirectory.file('gradle/publishing.gradle')}"

--- a/robolectric-extension/src/main/kotlin/tech/apter/junit/jupiter/robolectric/RobolectricExtension.kt
+++ b/robolectric-extension/src/main/kotlin/tech/apter/junit/jupiter/robolectric/RobolectricExtension.kt
@@ -30,6 +30,10 @@ class RobolectricExtension :
     private val beforeAllFired = AtomicBoolean(false)
     private val robolectricTestRunnerHelper by lazy { JUnit5RobolectricTestRunnerHelper() }
 
+    init {
+        logger.trace { "init" }
+    }
+
     override fun beforeAll(context: ExtensionContext) {
         logger.trace { "beforeAll ${context.requiredTestClass.name}" }
         robolectricTestRunnerHelper.createTestEnvironmentForClass(context.requiredTestClass)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality for publishing artifacts to Maven repositories.
	- Introduced `publishToMavenLocal` task to the Gradle build step.
	- Added a new property for version assignment.
	- Added task for generating Javadoc Jar.
	- Introduced `bashExecute` method for executing bash commands.

- **Refactor**
	- Renamed `version` property to `toolVersion` within the `detekt` configuration block.
	- Changed `detekt` version declaration to `toolVersion`.
	- Applied `publishing.gradle` script in `robolectric-extension/build.gradle`.

- **Documentation**
	- Added an initialization block in the `RobolectricExtension` class to log a message.
	- Updated logging in the `beforeAll` method to include the class name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->