### PR TITLE
ci: Publish plugin to the gradle plugin portal after tests finished successfully

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,20 +35,23 @@ jobs:
           ./bumpVersion.sh "${RELEASE_VERSION}"
         env:
           RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
-      - name: Publish Gradle Plugin
+      - name: Publish Gradle Plugin to Maven Local
         run: |
-          ./publishGradlePlugin.sh
-        env:
-          JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_KEY: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_KEY }}'
-          JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_SECRET: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_SECRET }}'
-          JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_KEY: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_KEY }}'
-          JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_PASSWORD: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_PASSWORD }}'
+          ./gradlew :robolectric-extension-gradle-plugin:publishToMavenLocal --configure-on-demand
       - name: Build with Gradle Wrapper
         run: |
           ./gradlew build koverXmlReport publish
         env:
           JUNIT5_ROBOLECTRIC_EXTENSION_MAVEN_USERNAME: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_MAVEN_USERNAME }}'
           JUNIT5_ROBOLECTRIC_EXTENSION_MAVEN_PASSWORD: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_MAVEN_PASSWORD }}'
+          JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_KEY: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_KEY }}'
+          JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_PASSWORD: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_PASSWORD }}'
+      - name: Publish Gradle Plugin
+        run: |
+          ./publishGradlePlugin.sh
+        env:
+          JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_KEY: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_KEY }}'
+          JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_SECRET: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_SECRET }}'
           JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_KEY: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_KEY }}'
           JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_PASSWORD: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_PASSWORD }}'
       - name: Upload coverage report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Publish Gradle Plugin to Maven Local
         run: |
           ./gradlew :robolectric-extension-gradle-plugin:publishToMavenLocal --configure-on-demand
+        env:
+          JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_KEY: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_KEY }}'
+          JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_PASSWORD: '${{ secrets.JUNIT5_ROBOLECTRIC_EXTENSION_GPG_SIGNING_PASSWORD }}'
       - name: Build with Gradle Wrapper
         run: |
           ./gradlew build koverXmlReport publish

--- a/publishGradlePlugin.sh
+++ b/publishGradlePlugin.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 function publishGradlePlugin() {
-  ./gradlew :robolectric-extension-gradle-plugin:publishToMavenLocal --configure-on-demand
   local -r robolectricGradlePluginVersion=$(cat < gradle.properties | grep tech.apter.junit5.robolectric.extension.version | cut -d'=' -f2)
 
   if [[ "$robolectricGradlePluginVersion" != *SNAPSHOT ]]; then
@@ -9,6 +8,8 @@ function publishGradlePlugin() {
       --configure-on-demand \
       -D"gradle.publish.key=${JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_KEY}" \
       -D"gradle.publish.secret=${JUNIT5_ROBOLECTRIC_EXTENSION_GRADLE_PLUGIN_PORTAL_SECRET}"
+  else
+    echo -e "publishGradlePlugin skipped. Run the following command if you want to publish the plugin locally:\n\t./gradlew :robolectric-extension-gradle-plugin:publishToMavenLocal --configure-on-demand\n"
   fi
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved the Gradle plugin publishing process by adding a condition to skip publishing snapshot versions and providing instructions for manual local publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->