### PR TITLE
ci: Run release job only on release versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       contents: write
     needs:
       - build
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.releaseVersion != '' && !endsWith(github.event.inputs.releaseVersion, "SNAPSHOT")
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.releaseVersion != '' && !endsWith(github.event.inputs.releaseVersion, 'SNAPSHOT')
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Create release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       contents: write
     needs:
       - build
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.releaseVersion != ''
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.releaseVersion != '' && !endsWith(github.event.inputs.releaseVersion, "SNAPSHOT")
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Create release

--- a/bumpVersion.sh
+++ b/bumpVersion.sh
@@ -24,7 +24,7 @@ function bumpVersion() {
   else
     local -r newVersion="$1"
   fi
-  sed -i .bak "s/^tech\.apter\.junit5\.robolectric\.extension\.version=.*/tech.apter.junit5.robolectric.extension.version=${newVersion}/" "$propertiesFile"
+  sed -i'.bak' "s/^tech\.apter\.junit5\.robolectric\.extension\.version=.*/tech.apter.junit5.robolectric.extension.version=${newVersion}/" "$propertiesFile"
   rm -rf "${propertiesFile}.bak"
   echo "$newVersion"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the build process by ensuring that release versions labeled as "SNAPSHOT" are excluded from certain workflow steps.
	- Updated version bump script to handle backup file creation more efficiently during the version update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->