### PR TITLE
fix: kotlin-dsl integration tests

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -24,6 +24,7 @@
             <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/integration-tests" />
             <option value="$PROJECT_DIR$/integration-tests/agp-groovy-dsl" />
+            <option value="$PROJECT_DIR$/integration-tests/agp-kotlin-dsl" />
             <option value="$PROJECT_DIR$/robolectric-extension" />
             <option value="$PROJECT_DIR$/robolectric-extension-gradle-plugin" />
           </set>

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinxKover)
 }
 
@@ -17,7 +18,7 @@ subprojects {
 
 dependencies {
     kover(project(':integration-tests:agp-groovy-dsl'))
-   // kover(project(':integration-tests:agp-kotlin-dsl'))
+    kover(project(':integration-tests:agp-kotlin-dsl'))
     kover(project(':robolectric-extension'))
     kover(project(':robolectric-extension-gradle-plugin'))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ sources = "sources"
 
 [libraries]
 androidGradleApi = { module = "com.android.tools.build:gradle-api", version.ref = "androidGradle" }
+androidGradle = { module = "com.android.tools.build:gradle", version.ref = "androidGradle" }
 androidGradleJava11 = { module = "com.android.tools.build:gradle", version = { require = "[7.0.0,8.0.0[", prefer = "7.4.2" } }
 androidToolsCommon = { module = "com.android.tools:common", version.ref = "androidToolsCommon" }
 androidxTestExtJunit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ dependencyResolutionManagement {
 
 rootProject.name = 'junit5-robolectric-extension'
 include('integration-tests:agp-groovy-dsl')
-//include('integration-tests:agp-kotlin-dsl')
+include('integration-tests:agp-kotlin-dsl')
 include('robolectric-extension')
 include('robolectric-extension-gradle-plugin')
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for Kotlin DSL integration tests, improving build configuration and flexibility for users who prefer Kotlin.
	- Added a new plugin alias for `androidLibrary`, enhancing control over plugin activation.
	- New library management for `androidGradle`, streamlining dependency management for the Android Gradle plugin.

- **Bug Fixes**
	- Reactivated inclusion of the Kotlin DSL project in the build configuration to enhance testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->