### PR TITLE
build: Change java version to 17 for robolectric-extension tests

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -25,6 +25,7 @@
             <option value="$PROJECT_DIR$/integration-tests" />
             <option value="$PROJECT_DIR$/integration-tests/agp-groovy-dsl" />
             <option value="$PROJECT_DIR$/integration-tests/agp-kotlin-dsl" />
+            <option value="$PROJECT_DIR$/integration-tests/java-11" />
             <option value="$PROJECT_DIR$/robolectric-extension" />
             <option value="$PROJECT_DIR$/robolectric-extension-gradle-plugin" />
           </set>

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ subprojects {
 dependencies {
     kover(project(':integration-tests:agp-groovy-dsl'))
     kover(project(':integration-tests:agp-kotlin-dsl'))
+    kover(project(':integration-tests:java-11'))
     kover(project(':robolectric-extension'))
     kover(project(':robolectric-extension-gradle-plugin'))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 androidBuildTools = "34.0.0"
 androidToolsCommon = "31.5.1"
 androidCompileSdk = "34"
+androidCompileSdkJava11 = "33"
 androidGradle = "8.5.1"
 androidMinimumSdk = "19"
 androidxTestExtJunit = "1.2.1"
@@ -23,7 +24,6 @@ sources = "sources"
 
 [libraries]
 androidGradleApi = { module = "com.android.tools.build:gradle-api", version.ref = "androidGradle" }
-androidGradle = { module = "com.android.tools.build:gradle", version.ref = "androidGradle" }
 androidGradleJava11 = { module = "com.android.tools.build:gradle", version = { require = "[7.0.0,8.0.0[", prefer = "7.4.2" } }
 androidToolsCommon = { module = "com.android.tools:common", version.ref = "androidToolsCommon" }
 androidxTestExtJunit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }

--- a/integration-tests/java-11/build.gradle
+++ b/integration-tests/java-11/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.kotlinxKover)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.robolectricExtensionGradlePlugin)
+}
+
+android {
+    namespace = 'tech.apter.junit.jupiter.robolectric.integration.tests.agp.groovy.dsl'
+    compileSdk = libs.versions.androidCompileSdkJava11.get().toInteger()
+    buildToolsVersion = libs.versions.androidBuildTools.get()
+
+    defaultConfig {
+        minSdk = libs.versions.androidMinimumSdk.get().toInteger()
+    }
+
+    testOptions {
+        unitTests.all { Test test ->
+            test.systemProperty('robolectric.enabledSdks', '19, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33')
+        }
+    }
+}
+
+detekt {
+    toolVersion = libs.versions.detekt.get()
+    autoCorrect = true
+}
+
+kotlin {
+    jvmToolchain(libs.versions.jvmToolchainMin.get().toInteger())
+}
+
+dependencies {
+    detektPlugins(libs.detektFormatting)
+    detektPlugins(libs.detektRulesLibraries)
+}

--- a/integration-tests/java-11/src/test/kotlin/tech/apter/junit/jupiter/robolectric/integration/tests/java11/Java11Test.kt
+++ b/integration-tests/java-11/src/test/kotlin/tech/apter/junit/jupiter/robolectric/integration/tests/java11/Java11Test.kt
@@ -1,0 +1,18 @@
+package tech.apter.junit.jupiter.robolectric.integration.tests.java11
+
+import android.os.Build
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+
+@ExtendWith(RobolectricExtension::class)
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+class Java11Test {
+    @Test
+    fun `Given an android project with kotlin-dsl build script when using Robolectric with JUnit5 the android app should be available`() {
+        assertNotNull(RuntimeEnvironment.getApplication())
+    }
+}

--- a/robolectric-extension/build.gradle
+++ b/robolectric-extension/build.gradle
@@ -39,6 +39,14 @@ test {
     systemProperty 'robolectric.usePreinstrumentedJars', 'true'
 }
 
+tasks.test {
+    javaLauncher.set(
+        javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(libs.versions.jvmToolchain.get().toInteger()))
+        }
+    )
+}
+
 detekt {
     toolVersion = libs.versions.detekt.get()
     autoCorrect true

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ dependencyResolutionManagement {
 rootProject.name = 'junit5-robolectric-extension'
 include('integration-tests:agp-groovy-dsl')
 include('integration-tests:agp-kotlin-dsl')
+include('integration-tests:java-11')
 include('robolectric-extension')
 include('robolectric-extension-gradle-plugin')
 


### PR DESCRIPTION
- adding an integration test to test with java 11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated directory for Java 11 integration tests to enhance testing processes.
	- Added support for Java 11 code coverage in the testing framework.
	- Integrated a new test suite specifically for Java 11 within the project structure.
  
- **Improvements**
	- Enhanced project configuration for better compatibility with Java 11 in the Android compilation process.
	- Streamlined testing setup with the integration of Robolectric and JUnit 5 for effective Android context testing.

- **Chores**
	- Updated project settings to include necessary configurations for Java 11 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->