### PR TITLE
chore: Remove unused suppress annotation

### DIFF
--- a/robolectric-extension/src/main/kotlin/tech/apter/junit/jupiter/robolectric/internal/JUnit5RobolectricTestRunnerHelper.kt
+++ b/robolectric-extension/src/main/kotlin/tech/apter/junit/jupiter/robolectric/internal/JUnit5RobolectricTestRunnerHelper.kt
@@ -1,5 +1,3 @@
-@file:Suppress("JAVA_MODULE_DOES_NOT_EXPORT_PACKAGE")
-
 package tech.apter.junit.jupiter.robolectric.internal
 
 import com.google.common.annotations.VisibleForTesting


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed a suppression annotation to enhance visibility checks for Java modules, improving compliance with module export rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->